### PR TITLE
fix: issue #112

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -30,5 +30,5 @@ export const attributeNameTag = 'data-watermark-tag';
 export const observeOptions = {
   childList: true,
   subtree: true,
-  attributeFilter: ['style', attributeNameTag],
+  attributeFilter: ['style', 'class', attributeNameTag],
 };


### PR DESCRIPTION
打开控制台选中element按下快捷键h会隐藏水印是因为添加了一个 class `__web-inspector-hide-shortcut__`，将 `class` 也加入到`attributeFilter` 中可以监测到此行为。