### PR TITLE
<doc>: 全局水印与其它遮罩层冲突 [issue 129]

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -243,13 +243,18 @@ export class Watermark {
 
     if (MutationObserver && this.options.monitor) {
       this.mutationObserver = new MutationObserver(mutations => {
+        // 避免多次执行render函数，导致多次注册MutationObserver 从而进入死循环逻辑
+        let lastMoutation;
         mutations.forEach(mutation => {
           if (this._isAgainRender(mutation)) {
-            this.destroy();
-            this._render();
+            lastMoutation = mutation;
             return;
           }
         });
+        if(lastMoutation){
+          this.destroy();
+          this._render();
+        }
       });
       this.mutationObserver.observe(this.container, observeOptions);
       this.shadowRoot && this.mutationObserver.observe(this.shadowRoot, observeOptions);


### PR DESCRIPTION
将MutationObserver触发事件,避免多次执行render函数，导致多次注册MutationObserver 从而进入死循环逻辑

Issue #129
Close #129